### PR TITLE
Windows Devstack Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Once you completed the steps described in the [Setup](#setup) section just do a 
 r10k will first bootstrap your local Puppet modules and after that the provisioning process will be started.
 This might not work if you are using non-Virtualbox providers.
 
+### Additional information for windows users
+ * You have to run `vagrant up` from the vagrant subdirectory
+ * You have to edit your `C:\Windows\System32\drivers\etc\hosts` file manually
+
 ## Notes
 ### Recommended Plugins
 The config makes use of but does not require:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,8 +14,8 @@ end
 
 provider   = (ENV['VAGRANT_DEFAULT_PROVIDER'] || :virtualbox).to_sym
 configfn   = Dir.glob('*/devstack.yaml', File::FNM_DOTMATCH)[0]
-basedir = File.absolute_path(File.dirname(configfn))
-vagrantdir = File.absolute_path(basedir == '..' ? '.' : 'vagrant')
+basedir    = File.absolute_path(File.dirname(configfn))
+vagrantdir = File.absolute_path(File.dirname(configfn) == '..' ? '.' : 'vagrant')
 cnf        = YAML::load(File.open(configfn))
 
 local_configfn = Dir.glob('*/local_devstack.yaml', File::FNM_DOTMATCH)[0]


### PR DESCRIPTION
This
- adds a note to compensate missing symlink support in Windows
- adds a note in regard to having to manually configure /etc/hosts on
  Windows (we should have a look at vagrant-hostmanager)
- fixes some path handling which causes vagrant commands from a subdir
  to fail
