### PR TITLE
Add notes for windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ r10k will first bootstrap your local Puppet modules and after that the provision
 This might not work if you are using non-Virtualbox providers.
 
 ### Additional information for windows users
+ * Executing `./vagrant/bootstrap.sh` just works from cmd.exe correctly, on cygwin you'll get some syntax errors
  * You have to run `vagrant up` from the vagrant subdirectory
  * You have to edit your `C:\Windows\System32\drivers\etc\hosts` file manually
 


### PR DESCRIPTION
It is not possible to execute the bootstrap.sh from cygwin

```
Maximilian@Maximilian /cygdrive/c/Sententiaregum/vagrant
$ bootstrap.sh
./bootstrap.sh: line 2: $'\r': Kommando nicht gefunden.
: Ungültige Optionne 3: set: -
set: usage: set [--abefhkmnptuvxBCHP] [-o option] [arg ...]
./bootstrap.sh: line 4: $'\r': Kommando nicht gefunden.
./bootstrap.sh: line 6: Syntaxfehler im bedingen Ausdruck.
'/bootstrap.sh: line 6: Syntaxfehler beim unerwarteten Wort `]]
'/bootstrap.sh: line 6: `if [[ "$OSTYPE" == *darwin* || "$OSTYPE" == *msys* ]]
```

So I've copied the devstack.yaml manually to avoid using the not correctly working bootstrap.sh.

I've checked out this just4fun on cmd.exe and the interesting thing was that it worked:

```
C:\>cd Sententiaregum/vagrant

C:\Sententiaregum\vagrant>bootstrap.sh
Welcome to Git (version 1.8.5.2-preview20131230)


Run 'git help git' to display the help index.
Run 'git help <command>' to display help for specific commands.
[bootstrap] link Vagrantfile to project root
[bootstrap] link .vagrant to project root
ln: `/c/Sententiaregum/vagrant/../.vagrant': cannot overwrite di
[bootstrap] create devstack.yaml in project root
cp: overwrite `/c/Sententiaregum/vagrant/../devstack.yaml'? n
```

So I've added that note
