### PR TITLE
extend the rabbitmq component to set user, vhost and user_permissions

### DIFF
--- a/site/component/manifests/rabbitmq.pp
+++ b/site/component/manifests/rabbitmq.pp
@@ -1,5 +1,28 @@
-class component::rabbitmq {
+class component::rabbitmq (
+  $users = {},
+  $vhosts = {},
+  $userpermissions = {}
+) {
+  validate_array($vhosts)
+  validate_hash($users)
+  validate_hash($userpermissions)
+
   anchor { 'component::rabbitmq::begin': } ->
     class { '::rabbitmq': } ->
   anchor { 'component::rabbitmq::end': }
+
+  create_resources('rabbitmq_user', $users, {
+    require => Anchor['component::rabbitmq::begin'],
+    before  => Anchor['component::rabbitmq::end']
+  })
+
+  create_resources('rabbitmq_vhost', $vhosts, {
+    require => Anchor['component::rabbitmq::begin'],
+    before  => Anchor['component::rabbitmq::end']
+  })
+
+  create_resources('rabbitmq_user_permissions', $userpermissions, {
+    require => Anchor['component::rabbitmq::begin'],
+    before  => Anchor['component::rabbitmq::end']
+  })
 }

--- a/vagrant-cfg.dist/common.yaml
+++ b/vagrant-cfg.dist/common.yaml
@@ -84,6 +84,50 @@ mysql::server::root_password: root
 
 # component::yii1::path: /var/www/app_name/app # path to folder containing index.php
 
+#component::rabbitmq::users:
+#    client:
+#      admin: true
+#      password: securepassword
+#    normaluser:
+#      admin: false
+#      password: othersecurepassword
+
+#component::rabbitmq::vhosts:
+#    /:
+#      ensure: absent
+#    development:
+#      ensure: present
+#    staging:
+#      ensure: present
+#    test:
+#      ensure: present
+
+#component::rabbitmq::userpermissions:
+#    client@development:
+#        read_permission: .*
+#        write_permission: .*
+#        configure_permission: .*
+#    client@staging:
+#        read_permission: .*
+#        write_permission: .*
+#        configure_permission: .*
+#    client@test:
+#        read_permission: .*
+#        write_permission: .*
+#        configure_permission: .*
+#    normaluser@development:
+#        read_permission: .*
+#        write_permission: .*
+#        configure_permission: .*
+#    normaluser@staging:
+#        read_permission: .*
+#        write_permission: .*
+#        configure_permission: .*
+#    normaluser@test:
+#        read_permission: .*
+#        write_permission: .*
+#        configure_permission: .*
+
 ## nginx (sendfile is turned off in dev)
 nginx::manage_repo: false
 


### PR DESCRIPTION
With this changes it is now possible to manage users, vhosts and userpermissions for the rabbitmq.
