### PR TITLE
git ignore .r10k_stamp to be consistent with related modules dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vagrant
 /modules/*
+/modules/.r10k_stamp
 /graphs/*
 /vendor/*


### PR DESCRIPTION
scenario:
- project initialized on computer A (creating modules and .r10k_stamp) and pushed
- clone on computer B
- vagrant up fails because it believes it has the modules