### PR TITLE
LXC and NixOS compatibility

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 

--- a/manifests/bootstrap.pp
+++ b/manifests/bootstrap.pp
@@ -1,5 +1,16 @@
 node default {
 
+  Exec {
+    path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+  }
+
+  if $::osfamily == 'Debian' {
+    exec { 'apt-update':
+      command => 'apt-get update',
+      unless  => 'which git',
+    } -> Package['ruby', 'git']
+  }
+
   package { ['ruby', 'git']:
     ensure        => installed,
     allow_virtual => true,
@@ -11,7 +22,6 @@ node default {
   } ->
 
   exec { 'r10k-puppetfile-install':
-    path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
     command => 'r10k -v info puppetfile install && touch modules/.r10k_stamp',
     cwd     => '/vagrant/vagrant',
     onlyif  => 'test ! -e modules/.r10k_stamp || test modules/.r10k_stamp -ot Puppetfile',


### PR DESCRIPTION
* disables hostmanager for non-writable /etc/hosts on a NixOS host
 * disables NFS with LXC provider
 * enables private networking only on VBox as this fails with LXC and is
   untested with other providers
 * runs an apt-get update prior to first apt run