### PR TITLE
Makeing it possible to change node version through yaml file

### DIFF
--- a/site/component/manifests/nodejs.pp
+++ b/site/component/manifests/nodejs.pp
@@ -1,7 +1,14 @@
-class component::nodejs {
+class component::nodejs (
+  $version      = 'stable',
+){
+  if !($version == 'stable') {
+    $make_install = true
+  } else {
+    $make_install = false
+  }
   class { '::nodejs':
-    version      => 'stable',
-    make_install => false
+    version      => $version,
+    make_install => $make_install
   }
   contain '::nodejs'
 }

--- a/vagrant-cfg.dist/common.yaml
+++ b/vagrant-cfg.dist/common.yaml
@@ -198,3 +198,6 @@ hhvm::config::port: 9090  # make sure that hhvm and php5-fpm ports don't collide
 # component::wordpress::ssl: true
 # component::wordpress::ssl_cert_dir: /etc/ssl/certs  # creates a .crt file named after the vhost in the specified path
 # component::wordpress::ssl_key_dir: /etc/ssl/private # does the same with a .key file
+
+## nodejs config
+# component::nodejs::version: stable # makes it possible to change the node version from stable to e.g. v0.8.22


### PR DESCRIPTION
You can now choose different versions of nodejs in the vagrant-cfg/common.yaml file. Other versions than stable must be build  during the provision (see "make_install" in nodejs.pp).